### PR TITLE
Changing early game logic to stay behind a bit, ...

### DIFF
--- a/src/sc/player2018/logic/EarlyGameLogic.java
+++ b/src/sc/player2018/logic/EarlyGameLogic.java
@@ -1,3 +1,9 @@
+/*
+ * early-game logic trading speed for many more carrots and an inherent position advantage. 
+ * Does not work well with mid-games involving staying behind, works best with a hybrid run/stay-mid-game, running if
+ * you were able to stay behind, staying once if you needed to run first.
+ */
+
 package sc.player2018.logic;
 
 import java.util.ArrayList;
@@ -13,32 +19,46 @@ public class EarlyGameLogic {
 
 	public static Move getTurn(GameState gameState) {
 		Player currentPlayer = gameState.getCurrentPlayer();
+		Player otherPlayer = gameState.getOtherPlayer();
 		ArrayList<Move> possibleMoves = gameState.getPossibleMoves();
-		MoveList baseList = new MoveList(possibleMoves,gameState);
+		MoveList baseList = new MoveList(possibleMoves, gameState);
 
-		if (currentPlayer.getSalads() == 5) {
-			// let's waste some turns in the beginning to lose a salad and wait for the
-			// enemy to move away
-			Move selectedMove = baseList.select(CardType.EAT_SALAD).getNearest();
-			if (selectedMove != null) {
-				return selectedMove;
-			}
-		} else {
-			// can we move to the next salad field?
-			if (gameState.isOccupied(SALAD_FIELD)) {
-				// no we can't
-				Move selectedMove = baseList.getNearest();
+		if (currentPlayer.getFieldIndex() < otherPlayer.getFieldIndex()) {
+			if (gameState.getNextFieldByType(FieldType.HARE, currentPlayer.getFieldIndex()) < otherPlayer
+					.getFieldIndex()) {
+				Move selectedMove = baseList.select(CardType.EAT_SALAD).getNearest();
 				if (selectedMove != null) {
 					return selectedMove;
 				}
-			} else {
-				// move to the salad field
+			}
+
+			if (SALAD_FIELD < otherPlayer.getFieldIndex()) {
 				Move selectedMove = baseList.select(FieldType.SALAD).getNearest();
 				if (selectedMove != null) {
 					return selectedMove;
 				}
-
 			}
+
+		}
+		if (currentPlayer.getCarrots() > 125) { // random value oriented on KvC, calculate a better one
+			if (!gameState.isOccupied(SALAD_FIELD)) {
+				Move selectedMove = baseList.select(FieldType.SALAD).getNearest();
+				if (selectedMove != null) {
+					return selectedMove;
+				}
+			}
+		}
+		if (gameState.getTypeAt(currentPlayer.getFieldIndex()) == FieldType.CARROT) {
+			Move selectedMove = baseList.getCarrotExchange(10);
+			if (selectedMove != null) {
+				return selectedMove;
+			}
+		}
+		Move selectedMove = baseList.deselect(CardType.HURRY_AHEAD).deselect(CardType.EAT_SALAD)
+				.deselect(CardType.TAKE_OR_DROP_CARROTS, -20).deselect(CardType.TAKE_OR_DROP_CARROTS, 0)
+				.deselect(CardType.EAT_SALAD).getNearest();
+		if (selectedMove != null) {
+			return selectedMove;
 		}
 
 		return null;


### PR DESCRIPTION
… can be worse, even or better, depending on the following mid-game strategy. This change is prerequisite for further changes to mid- and end-game, as the shear number of carrots gotten through this method in the early game enables a running strategy, shown to be more effective by teams such as KvC